### PR TITLE
Convert entity relation name back to camel case before querying

### DIFF
--- a/libs/json-api-nestjs/src/lib/helper/utils/index.ts
+++ b/libs/json-api-nestjs/src/lib/helper/utils/index.ts
@@ -54,3 +54,10 @@ export function getProviderName(entity: EntityTarget<Entity>, name: string) {
   const entityName = getEntityName(entity);
   return `${upperFirstLetter(entityName)}${name}`;
 }
+
+export function kebabToCamel(str: string) {
+  return str
+    .split('-')
+    .map((i) => i.charAt(0).toUpperCase() + i.substring(1))
+    .join('');
+}

--- a/libs/json-api-nestjs/src/lib/mixin/pipes/body-input-post/body-input-post.pipe.spec.ts
+++ b/libs/json-api-nestjs/src/lib/mixin/pipes/body-input-post/body-input-post.pipe.spec.ts
@@ -269,6 +269,12 @@ describe('BodyInputPostPipe', () => {
               id: '1',
             },
           },
+          userGroup: {
+            data: {
+              type: 'user-groups',
+              id: '1',
+            },
+          },
         },
       },
     };
@@ -299,6 +305,12 @@ describe('BodyInputPostPipe', () => {
           addresses: {
             data: {
               type: 'addresses',
+              id: '1',
+            },
+          },
+          userGroup: {
+            data: {
+              type: 'user-groups',
               id: '1',
             },
           },

--- a/libs/json-api-nestjs/src/lib/mixin/service/typeorm/utils/utils-methode.spec.ts
+++ b/libs/json-api-nestjs/src/lib/mixin/service/typeorm/utils/utils-methode.spec.ts
@@ -7,6 +7,7 @@ import {
   Users,
   Roles,
   Addresses,
+  UserGroups,
 } from '../../../../mock-utils';
 import { DEFAULT_CONNECTION_NAME } from '../../../../constants';
 import { UtilsMethode } from './utils-methode';
@@ -46,6 +47,12 @@ describe('Utils methode test', () => {
       })
     );
 
+    const userGroup = await repository.manager.getRepository(UserGroups).save(
+      Object.assign(new UserGroups(), {
+        label: 'Editors',
+      })
+    );
+
     await repository.manager.getRepository(Roles).save(
       Object.assign(new Roles(), {
         name: 'user',
@@ -62,6 +69,7 @@ describe('Utils methode test', () => {
         isActive: true,
         login: 'login',
         addresses: address,
+        userGroups: userGroup,
       })
     );
   });
@@ -678,6 +686,30 @@ describe('Utils methode test', () => {
       expect(Array.isArray(result[0].rel)).toBe(true);
       expect(result[0].rel).toEqual([]);
       expect(result[0].type).toBe(null);
+      expect(result[0].propsName).toBe(Object.keys(data)[0]);
+    });
+
+    it('should be ok if relation entity name is compound', async () => {
+      const data: ResourceRequestObject<Users>['data']['relationships'] = {
+        userGroup: {
+          data: {
+            type: 'user-groups',
+            id: '1',
+          },
+        },
+      };
+      const result = [];
+      for await (const tmp of UtilsMethode.asyncIterateFindRelationships(
+        data,
+        repository
+      )) {
+        result.push(tmp);
+      }
+      expect(result.length).toBe(1);
+      expect(result[0].id).toBe(data.userGroup.data.id);
+      expect(Array.isArray(result[0].rel)).toBe(false);
+      expect(result[0].rel).toBeInstanceOf(UserGroups);
+      expect(result[0].type).toBe(data.userGroup.data.type);
       expect(result[0].propsName).toBe(Object.keys(data)[0]);
     });
   });

--- a/libs/json-api-nestjs/src/lib/mixin/service/typeorm/utils/utils-methode.ts
+++ b/libs/json-api-nestjs/src/lib/mixin/service/typeorm/utils/utils-methode.ts
@@ -18,7 +18,12 @@ import {
   ServiceOptions,
   ValidationError,
 } from '../../../../types';
-import { snakeToCamel, getEntityName, camelToKebab } from '../../../../helper';
+import {
+  snakeToCamel,
+  getEntityName,
+  camelToKebab,
+  kebabToCamel,
+} from '../../../../helper';
 import {
   OperandMapForNull,
   OperandMapForNullRelation,
@@ -355,7 +360,7 @@ export class UtilsMethode {
       const relationsTypeName = isArray ? data[0]['type'] : data['type'];
 
       const result = await repository.manager
-        .getRepository(relationsTypeName)
+        .getRepository(kebabToCamel(relationsTypeName))
         .find({
           select: {
             id: true,

--- a/libs/json-api-nestjs/src/lib/mock-utils/db-for-test
+++ b/libs/json-api-nestjs/src/lib/mock-utils/db-for-test
@@ -286,9 +286,19 @@ CREATE TABLE public.users (
     is_active boolean DEFAULT false,
     manager_id integer,
     addresses_id integer NOT NULL,
+    user_groups_id integer,
     created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
     test_date timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
     updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+--
+-- Name: user_groups; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.user_groups (
+    id integer NOT NULL,
+    label character varying NOT NULL
 );
 
 
@@ -343,6 +353,25 @@ CREATE SEQUENCE public.users_id_seq
 --
 
 ALTER SEQUENCE public.users_id_seq OWNED BY public.users.id;
+
+
+--
+-- Name: user_groups_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.user_groups_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+--
+-- Name: user_groups_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.user_groups_id_seq OWNED BY public.user_groups.id;
 
 
 --
@@ -402,6 +431,13 @@ ALTER TABLE ONLY public.users ALTER COLUMN id SET DEFAULT nextval('public.users_
 
 
 --
+-- Name: users id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_groups ALTER COLUMN id SET DEFAULT nextval('public.user_groups_id_seq'::regclass);
+
+
+--
 -- Name: users_have_roles id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -455,6 +491,13 @@ ALTER TABLE ONLY public.users_have_roles
 ALTER TABLE ONLY public.users
     ADD CONSTRAINT "PK_a3ffb1c0c8416b9fc6f907b7433" PRIMARY KEY (id);
 
+
+--
+-- Name: users PK_user_groups; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_groups
+    ADD CONSTRAINT "PK_user_groups" PRIMARY KEY (id);
 
 --
 -- Name: pods PK_b00bbc2c7fb41627be2b169f0dd; Type: CONSTRAINT; Schema: public; Owner: -
@@ -516,6 +559,13 @@ CREATE UNIQUE INDEX "IDX_61c360686dfe8d62a9b03873bf" ON public.users_have_roles 
 
 ALTER TABLE ONLY public.users
     ADD CONSTRAINT "FK_2f8d527df0d3acb8aa51945a968" FOREIGN KEY (addresses_id) REFERENCES public.addresses(id);
+
+
+--
+-- Name: users FK_user_groups; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+ALTER TABLE ONLY public.users
+    ADD CONSTRAINT "FK_user_groups" FOREIGN KEY (user_groups_id) REFERENCES public.user_groups(id);
 
 
 --

--- a/libs/json-api-nestjs/src/lib/mock-utils/entities/index.ts
+++ b/libs/json-api-nestjs/src/lib/mock-utils/entities/index.ts
@@ -5,3 +5,4 @@ export * from './requests';
 export * from './pods';
 export * from './comments';
 export * from './addresses';
+export * from './user-groups';

--- a/libs/json-api-nestjs/src/lib/mock-utils/entities/user-groups.ts
+++ b/libs/json-api-nestjs/src/lib/mock-utils/entities/user-groups.ts
@@ -1,0 +1,23 @@
+import { PrimaryGeneratedColumn, OneToMany, Entity, Column } from 'typeorm';
+import { IsNotEmpty, Length } from 'class-validator';
+
+import { IUsers, Users } from '.';
+
+@Entity('user_groups')
+export class UserGroups {
+  @PrimaryGeneratedColumn()
+  public id: number;
+
+  @IsNotEmpty()
+  @Length(3, 50)
+  @Column({
+    type: 'varchar',
+    length: 50,
+    nullable: false,
+    unique: true,
+  })
+  public label: string;
+
+  @OneToMany(() => Users, (item) => item.userGroup)
+  public users: IUsers[];
+}

--- a/libs/json-api-nestjs/src/lib/mock-utils/entities/users.ts
+++ b/libs/json-api-nestjs/src/lib/mock-utils/entities/users.ts
@@ -8,6 +8,7 @@ import {
   Entity,
   Column,
   UpdateDateColumn,
+  ManyToOne,
 } from 'typeorm';
 import {
   Length,
@@ -20,6 +21,7 @@ import {
 import { Exclude } from 'class-transformer';
 
 import { Addresses, Roles, Comments } from '.';
+import { UserGroups } from './user-groups';
 
 export type IUsers = Users;
 
@@ -128,4 +130,9 @@ export class Users {
 
   @OneToMany(() => Comments, (item) => item.createdBy)
   public comments: Comments[];
+
+  @ManyToOne(() => UserGroups, (userGroup) => userGroup.id)
+  @IsNotEmpty()
+  @JoinColumn({ name: 'user_groups_id' })
+  public userGroup: UserGroups;
 }

--- a/libs/json-api-nestjs/src/lib/mock-utils/index.ts
+++ b/libs/json-api-nestjs/src/lib/mock-utils/index.ts
@@ -12,6 +12,7 @@ import {
   Pods,
   Comments,
   Addresses,
+  UserGroups,
 } from './entities';
 import { DataSource } from 'typeorm';
 
@@ -19,6 +20,7 @@ export * from './entities';
 
 export const entities = [
   Users,
+  UserGroups,
   Roles,
   RequestsHavePodLocks,
   Requests,
@@ -52,6 +54,7 @@ export function mockDBTestModule(): DynamicModule {
         type: 'postgres',
         entities: [
           Users,
+          UserGroups,
           Roles,
           RequestsHavePodLocks,
           Requests,


### PR DESCRIPTION
Fixes #28.

Sometimes an entity would not be found while trying to `POST` a resource with its relationship.
Like mentioned in the issue, we need to convert our entity name back to camel case before querying.