### PR TITLE
Only return unique values in relationship object response

### DIFF
--- a/libs/json-api-nestjs/src/lib/mixin/service/transform/transform.mixin.ts
+++ b/libs/json-api-nestjs/src/lib/mixin/service/transform/transform.mixin.ts
@@ -186,17 +186,21 @@ export class TransformMixinService<T> {
         const propsData = data[field];
         const typeName = getEntityName(this.relationTarget.get(field));
         if (Array.isArray(propsData)) {
-          builtData.data = propsData
-            .map((i) => ({
-              type: camelToKebab(typeName),
-              id: i[this.relationPrimaryField.get(field)].toString(),
-            }))
-            .reduce((acum, i) => {
-              if (acum.find((a) => a.id === i.id)) {
-                return acum;
-              }
-              return [...acum, i];
-            }, []);
+          const tmp = propsData.reduce((acum, item) => {
+            const key = `${camelToKebab(typeName)}:${item[
+              this.relationPrimaryField.get(field)
+            ].toString()}`;
+
+            if (!acum.has(key)) {
+              acum.set(key, {
+                type: camelToKebab(typeName),
+                id: item[this.relationPrimaryField.get(field)].toString(),
+              });
+            }
+
+            return acum;
+          }, new Map());
+          builtData.data = [...tmp.values()];
         }
 
         if (!Array.isArray(data[field]) && typeof data[field] !== 'undefined') {

--- a/libs/json-api-nestjs/src/lib/mixin/service/transform/transform.mixin.ts
+++ b/libs/json-api-nestjs/src/lib/mixin/service/transform/transform.mixin.ts
@@ -186,10 +186,17 @@ export class TransformMixinService<T> {
         const propsData = data[field];
         const typeName = getEntityName(this.relationTarget.get(field));
         if (Array.isArray(propsData)) {
-          builtData.data = propsData.map((i) => ({
-            type: camelToKebab(typeName),
-            id: i[this.relationPrimaryField.get(field)].toString(),
-          }));
+          builtData.data = propsData
+            .map((i) => ({
+              type: camelToKebab(typeName),
+              id: i[this.relationPrimaryField.get(field)].toString(),
+            }))
+            .reduce((acum, i) => {
+              if (acum.find((a) => a.id === i.id)) {
+                return acum;
+              }
+              return [...acum, i];
+            }, []);
         }
 
         if (!Array.isArray(data[field]) && typeof data[field] !== 'undefined') {

--- a/libs/json-api-nestjs/src/lib/mock-utils/db-for-test
+++ b/libs/json-api-nestjs/src/lib/mock-utils/db-for-test
@@ -99,6 +99,39 @@ ALTER SEQUENCE public.comments_id_seq OWNED BY public.comments.id;
 
 
 --
+-- Name: notes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.notes (
+    id integer NOT NULL,
+    text text NOT NULL,
+    created_by integer,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+--
+-- Name: notes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.notes_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: notes_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.notes_id_seq OWNED BY public.notes.id;
+
+
+--
 -- Name: migrations; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -389,6 +422,13 @@ ALTER TABLE ONLY public.comments ALTER COLUMN id SET DEFAULT nextval('public.com
 
 
 --
+-- Name: notes id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.notes ALTER COLUMN id SET DEFAULT nextval('public.notes_id_seq'::regclass);
+
+
+--
 -- Name: migrations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -467,6 +507,13 @@ ALTER TABLE ONLY public.addresses
 ALTER TABLE ONLY public.comments
     ADD CONSTRAINT "PK_8bf68bc960f2b69e818bdb90dcb" PRIMARY KEY (id);
 
+
+--
+-- Name: notes PK_notes; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.notes
+    ADD CONSTRAINT "PK_notes" PRIMARY KEY (id);
 
 --
 -- Name: migrations PK_8c82d7f526340ab734260ea46be; Type: CONSTRAINT; Schema: public; Owner: -
@@ -582,6 +629,14 @@ ALTER TABLE ONLY public.users_have_roles
 
 ALTER TABLE ONLY public.comments
     ADD CONSTRAINT "FK_980bfefe00ed11685f325d0bd4c" FOREIGN KEY (created_by) REFERENCES public.users(id);
+
+
+--
+-- Name: notes FK_980bfefe00ed11685f325d0bd4c; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.notes
+    ADD CONSTRAINT "FK_notes" FOREIGN KEY (created_by) REFERENCES public.users(id);
 
 
 --

--- a/libs/json-api-nestjs/src/lib/mock-utils/entities/index.ts
+++ b/libs/json-api-nestjs/src/lib/mock-utils/entities/index.ts
@@ -6,3 +6,4 @@ export * from './pods';
 export * from './comments';
 export * from './addresses';
 export * from './user-groups';
+export * from './notes';

--- a/libs/json-api-nestjs/src/lib/mock-utils/entities/notes.ts
+++ b/libs/json-api-nestjs/src/lib/mock-utils/entities/notes.ts
@@ -1,0 +1,49 @@
+import {
+  PrimaryGeneratedColumn,
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  UpdateDateColumn,
+} from 'typeorm';
+import { IsEmpty, IsNotEmpty } from 'class-validator';
+
+import { Users, IUsers } from '.';
+
+@Entity('notes')
+export class Notes {
+  @PrimaryGeneratedColumn()
+  public id: number;
+
+  @IsNotEmpty()
+  @Column({
+    type: 'text',
+    nullable: false,
+  })
+  public text: string;
+
+  @IsEmpty()
+  @Column({
+    name: 'created_at',
+    type: 'timestamp',
+    nullable: true,
+    default: 'CURRENT_TIMESTAMP',
+  })
+  public createdAt: Date;
+
+  @IsEmpty()
+  @UpdateDateColumn({
+    name: 'updated_at',
+    type: 'timestamp',
+    nullable: true,
+    default: 'CURRENT_TIMESTAMP',
+  })
+  public updatedAt: Date;
+
+  @ManyToOne(() => Users, (item) => item.notes)
+  @IsNotEmpty()
+  @JoinColumn({
+    name: 'created_by',
+  })
+  public createdBy: IUsers;
+}

--- a/libs/json-api-nestjs/src/lib/mock-utils/entities/users.ts
+++ b/libs/json-api-nestjs/src/lib/mock-utils/entities/users.ts
@@ -20,8 +20,7 @@ import {
 
 import { Exclude } from 'class-transformer';
 
-import { Addresses, Roles, Comments } from '.';
-import { UserGroups } from './user-groups';
+import { Addresses, Roles, Comments, Notes, UserGroups } from '.';
 
 export type IUsers = Users;
 
@@ -130,6 +129,9 @@ export class Users {
 
   @OneToMany(() => Comments, (item) => item.createdBy)
   public comments: Comments[];
+
+  @OneToMany(() => Notes, (item) => item.createdBy)
+  public notes: Notes[];
 
   @ManyToOne(() => UserGroups, (userGroup) => userGroup.id)
   @IsNotEmpty()

--- a/libs/json-api-nestjs/src/lib/mock-utils/index.ts
+++ b/libs/json-api-nestjs/src/lib/mock-utils/index.ts
@@ -13,6 +13,7 @@ import {
   Comments,
   Addresses,
   UserGroups,
+  Notes,
 } from './entities';
 import { DataSource } from 'typeorm';
 
@@ -27,6 +28,7 @@ export const entities = [
   Pods,
   Comments,
   Addresses,
+  Notes,
 ];
 
 const dump = readFileSync(join(__dirname, 'db-for-test'), { encoding: 'utf8' });
@@ -61,6 +63,7 @@ export function mockDBTestModule(): DynamicModule {
           Pods,
           Comments,
           Addresses,
+          Notes,
         ],
       };
     },


### PR DESCRIPTION
### The issue
When including related entities on a GET endpoint, some relationships will be duplicated:

![image](https://user-images.githubusercontent.com/22935809/226265183-4ffeac48-35f8-464a-a24c-019fc88ee5a2.png)

### Solution
Reduce [this array](https://github.com/Mites-G/nestjs-json-api/blob/master/libs/json-api-nestjs/src/lib/mixin/service/transform/transform.mixin.ts) to only hold unique objects.

Please let me know if there's any way to improve my solution.

### Tests
New test failing before fix
![image](https://user-images.githubusercontent.com/22935809/226265915-ab696473-1199-415b-a9db-251d66e8be10.png)

All tests passing after fix
![image](https://user-images.githubusercontent.com/22935809/226266021-423c4f01-ef04-496a-b8f4-1a217c51d478.png)
