### PR TITLE
Route name override

### DIFF
--- a/libs/json-api-nestjs/README.md
+++ b/libs/json-api-nestjs/README.md
@@ -83,6 +83,7 @@ import {ExampleService} from '../../service/example/example.service';
 @JsonApi(Users, {
   allowMethod: excludeMethod(['deleteRelationship']),
   requiredSelectField: true,
+  overrideName: 'user',
 })
 export class ExtendUserController extends JsonBaseController<Users> {
   @InjectService() public service: JsonApiService<Users>;

--- a/libs/json-api-nestjs/README.md
+++ b/libs/json-api-nestjs/README.md
@@ -83,7 +83,7 @@ import {ExampleService} from '../../service/example/example.service';
 @JsonApi(Users, {
   allowMethod: excludeMethod(['deleteRelationship']),
   requiredSelectField: true,
-  overrideName: 'user',
+  overrideRoute: 'user',
 })
 export class ExtendUserController extends JsonBaseController<Users> {
   @InjectService() public service: JsonApiService<Users>;

--- a/libs/json-api-nestjs/src/lib/decorators/json-api/json-api.decorator.spec.ts
+++ b/libs/json-api-nestjs/src/lib/decorators/json-api/json-api.decorator.spec.ts
@@ -52,11 +52,11 @@ describe('InjectServiceDecorator', () => {
     );
   });
 
-  it('should save options in class and correctly set overrideName', () => {
+  it('should save options in class and correctly set overrideRoute', () => {
     const testedEntity = class SomeEntity {};
     const apiOptions: DecoratorOptions = {
       allowMethod: ['getAll', 'deleteRelationship'],
-      overrideName: '123'
+      overrideRoute: '123'
     };
 
     @JsonApi(testedEntity, apiOptions)

--- a/libs/json-api-nestjs/src/lib/decorators/json-api/json-api.decorator.spec.ts
+++ b/libs/json-api-nestjs/src/lib/decorators/json-api/json-api.decorator.spec.ts
@@ -51,4 +51,18 @@ describe('InjectServiceDecorator', () => {
       Object.keys(Bindings).filter((k) => !example.includes(k))
     );
   });
+
+  it('should save options in class and correctly set overrideName', () => {
+    const testedEntity = class SomeEntity {};
+    const apiOptions: DecoratorOptions = {
+      allowMethod: ['getAll', 'deleteRelationship'],
+      overrideName: '123'
+    };
+
+    @JsonApi(testedEntity, apiOptions)
+    class SomeClass {}
+
+    const data = Reflect.getMetadata(JSON_API_DECORATOR_OPTIONS, SomeClass);
+    expect(data).toEqual(apiOptions);
+  });
 });

--- a/libs/json-api-nestjs/src/lib/helper/swagger/index.ts
+++ b/libs/json-api-nestjs/src/lib/helper/swagger/index.ts
@@ -24,7 +24,7 @@ export function setSwaggerDecorator(
     const entityName =
       entity instanceof Function ? entity.name : entity.options.name;
 
-    ApiTags(config['overrideName'] || `${camelToKebab(entityName)}`)(
+    ApiTags(config?.['overrideName'] || `${camelToKebab(entityName)}`)(
       controller
     );
   }

--- a/libs/json-api-nestjs/src/lib/helper/swagger/index.ts
+++ b/libs/json-api-nestjs/src/lib/helper/swagger/index.ts
@@ -24,7 +24,7 @@ export function setSwaggerDecorator(
     const entityName =
       entity instanceof Function ? entity.name : entity.options.name;
 
-    ApiTags(config?.['overrideName'] || `${camelToKebab(entityName)}`)(
+    ApiTags(config?.['overrideRoute'] || `${camelToKebab(entityName)}`)(
       controller
     );
   }

--- a/libs/json-api-nestjs/src/lib/helper/swagger/index.ts
+++ b/libs/json-api-nestjs/src/lib/helper/swagger/index.ts
@@ -24,11 +24,9 @@ export function setSwaggerDecorator(
     const entityName =
       entity instanceof Function ? entity.name : entity.options.name;
 
-    const resourceName = config.overrideName
-      ? config.overrideName
-      : `${camelToKebab(entityName)}`;
-
-    ApiTags(resourceName)(controller);
+    ApiTags(config['overrideName'] || `${camelToKebab(entityName)}`)(
+      controller
+    );
   }
   ApiExtraModels(FilterOperand)(controller);
   ApiExtraModels(createApiModels(entity))(controller);

--- a/libs/json-api-nestjs/src/lib/helper/swagger/index.ts
+++ b/libs/json-api-nestjs/src/lib/helper/swagger/index.ts
@@ -23,7 +23,12 @@ export function setSwaggerDecorator(
   if (!apiTag) {
     const entityName =
       entity instanceof Function ? entity.name : entity.options.name;
-    ApiTags(camelToKebab(entityName))(controller);
+
+    const resourceName = config.overrideName
+      ? config.overrideName
+      : `${camelToKebab(entityName)}`;
+
+    ApiTags(resourceName)(controller);
   }
   ApiExtraModels(FilterOperand)(controller);
   ApiExtraModels(createApiModels(entity))(controller);

--- a/libs/json-api-nestjs/src/lib/mixin/module/module.mixin.ts
+++ b/libs/json-api-nestjs/src/lib/mixin/module/module.mixin.ts
@@ -53,7 +53,7 @@ BaseModuleClass.forRoot = function (options): DynamicModule {
 
   const transformService = transformMixin(entity, connectionName);
   const serviceClass = typeormMixin(entity, connectionName, transformService);
-  Controller(decoratorOptions?.['overrideName'] || `${camelToKebab(entityName)}`)(
+  Controller(decoratorOptions?.['overrideRoute'] || `${camelToKebab(entityName)}`)(
     controllerClass
   );
   UseInterceptors(ErrorInterceptors)(controllerClass);

--- a/libs/json-api-nestjs/src/lib/mixin/module/module.mixin.ts
+++ b/libs/json-api-nestjs/src/lib/mixin/module/module.mixin.ts
@@ -53,7 +53,7 @@ BaseModuleClass.forRoot = function (options): DynamicModule {
 
   const transformService = transformMixin(entity, connectionName);
   const serviceClass = typeormMixin(entity, connectionName, transformService);
-  Controller(decoratorOptions['overrideName'] || `${camelToKebab(entityName)}`)(
+  Controller(decoratorOptions?.['overrideName'] || `${camelToKebab(entityName)}`)(
     controllerClass
   );
   UseInterceptors(ErrorInterceptors)(controllerClass);

--- a/libs/json-api-nestjs/src/lib/mixin/module/module.mixin.ts
+++ b/libs/json-api-nestjs/src/lib/mixin/module/module.mixin.ts
@@ -18,7 +18,6 @@ import {
   getProviderName,
   camelToKebab,
 } from '../../helper';
-import { JsonBaseController } from '../controller';
 import { typeormMixin, transformMixin } from '../';
 import {
   JSON_API_DECORATOR_OPTIONS,
@@ -52,13 +51,11 @@ BaseModuleClass.forRoot = function (options): DynamicModule {
     controllerClass
   );
 
-  const resourceName = decoratorOptions?.overrideName
-    ? decoratorOptions.overrideName
-    : `${camelToKebab(entityName)}`;
-
   const transformService = transformMixin(entity, connectionName);
   const serviceClass = typeormMixin(entity, connectionName, transformService);
-  Controller(resourceName)(controllerClass);
+  Controller(decoratorOptions['overrideName'] || `${camelToKebab(entityName)}`)(
+    controllerClass
+  );
   UseInterceptors(ErrorInterceptors)(controllerClass);
   Inject(serviceClass)(controllerClass.prototype, 'serviceMixin');
   const properties = Reflect.getMetadata(

--- a/libs/json-api-nestjs/src/lib/mixin/module/module.mixin.ts
+++ b/libs/json-api-nestjs/src/lib/mixin/module/module.mixin.ts
@@ -46,9 +46,19 @@ BaseModuleClass.forRoot = function (options): DynamicModule {
   const controllerClass =
     controller ||
     nameIt(getProviderName(entity, JSON_API_CONTROLLER_POSTFIX), class {});
+
+  const decoratorOptions: DecoratorOptions = Reflect.getMetadata(
+    JSON_API_DECORATOR_OPTIONS,
+    controllerClass
+  );
+
+  const resourceName = decoratorOptions?.overrideName
+    ? decoratorOptions.overrideName
+    : `${camelToKebab(entityName)}`;
+
   const transformService = transformMixin(entity, connectionName);
   const serviceClass = typeormMixin(entity, connectionName, transformService);
-  Controller(`${camelToKebab(entityName)}`)(controllerClass);
+  Controller(resourceName)(controllerClass);
   UseInterceptors(ErrorInterceptors)(controllerClass);
   Inject(serviceClass)(controllerClass.prototype, 'serviceMixin');
   const properties = Reflect.getMetadata(
@@ -73,10 +83,7 @@ BaseModuleClass.forRoot = function (options): DynamicModule {
       controllerClass
     );
   }
-  const decoratorOptions: DecoratorOptions = Reflect.getMetadata(
-    JSON_API_DECORATOR_OPTIONS,
-    controllerClass
-  );
+
   const moduleConfig: ConfigParam = {
     ...ConfigParamDefault,
     ...options.config,

--- a/libs/json-api-nestjs/src/lib/types/module.types.ts
+++ b/libs/json-api-nestjs/src/lib/types/module.types.ts
@@ -18,6 +18,7 @@ export interface ConfigParam {
   debug: boolean;
   maxExecutionTime: number;
   pipeForId: PipeMixin;
+  overrideName?: string;
 }
 
 export interface ModuleOptions {

--- a/libs/json-api-nestjs/src/lib/types/module.types.ts
+++ b/libs/json-api-nestjs/src/lib/types/module.types.ts
@@ -18,7 +18,7 @@ export interface ConfigParam {
   debug: boolean;
   maxExecutionTime: number;
   pipeForId: PipeMixin;
-  overrideName?: string;
+  overrideRoute?: string;
 }
 
 export interface ModuleOptions {


### PR DESCRIPTION
Adds the ability to override a resource route name in controller decorator options, for instance:

```ts
@JsonApi(Users, {
  allowMethod: excludeMethod(['deleteRelationship']),
  requiredSelectField: false,
  overrideRoute: 'user',
})
export class ExtendUserController extends JsonBaseController<Users> {}
```

Fixes #27 