### PR TITLE
Route overrides on relationship links

### DIFF
--- a/libs/json-api-nestjs/src/lib/mixin/service/transform/transform.mixin.ts
+++ b/libs/json-api-nestjs/src/lib/mixin/service/transform/transform.mixin.ts
@@ -165,7 +165,7 @@ export class TransformMixinService<T> {
     include: string[] = [],
     table = this.currentResourceName
   ): ResourceData<T> {
-    const urlTable = camelToKebab(table);
+    const urlTable = this.config?.['overrideRoute'] || camelToKebab(table);
     const attributes = {} as Attributes<Omit<T, 'id'>>;
     const relationships = {} as Partial<Relationships<T>>;
 

--- a/libs/json-api-nestjs/src/lib/mixin/service/typeorm/methods/get-one/get-one.spec.ts
+++ b/libs/json-api-nestjs/src/lib/mixin/service/typeorm/methods/get-one/get-one.spec.ts
@@ -154,6 +154,23 @@ describe('GetOne methode test', () => {
     }
   });
 
+  it('should be correct if route is overriden', async () => {
+    expect.assertions(2);
+    configParam.overrideRoute = 'overridden';
+
+    const response = await typeormService.getOne({
+      query: defaultField,
+      route: { id: params },
+    });
+
+    expect(response.data['relationships'].addresses.links.related).toContain(
+      'overridden'
+    );
+    expect(response.data['relationships'].addresses.links.self).toContain(
+      'overridden'
+    );
+  });
+
   it('should be error if item not exist', async () => {
     expect.assertions(1);
     configParam.requiredSelectField = false;


### PR DESCRIPTION
Since the route overrides #43 PR, I realized I forgot to make so relationship `self` and `related` links comply with the overridden route name.

So here is the simple solution following the same pattern we did on the earlier PR.

Also, a test case showing off this situation.