### PR TITLE
fix(json-api-nestjs): Revert resource type when path is overridden

### DIFF
--- a/libs/json-api-nestjs/src/lib/mixin/service/transform/transform.mixin.ts
+++ b/libs/json-api-nestjs/src/lib/mixin/service/transform/transform.mixin.ts
@@ -165,7 +165,8 @@ export class TransformMixinService<T> {
     include: string[] = [],
     table = this.currentResourceName
   ): ResourceData<T> {
-    const urlTable = this.config?.['overrideRoute'] || camelToKebab(table);
+    const urlTable = camelToKebab(table);
+    const routePath = this.config?.['overrideRoute'] || camelToKebab(table);
     const attributes = {} as Attributes<Omit<T, 'id'>>;
     const relationships = {} as Partial<Relationships<T>>;
 
@@ -214,13 +215,13 @@ export class TransformMixinService<T> {
           ...(include.includes(field) && builtData.data ? builtData : {}),
           links: {
             self: this.getLink(
-              urlTable,
+              routePath,
               data[this.relationPrimaryField.get(field)],
               'relationships',
               camelToKebab(field)
             ),
             related: this.getLink(
-              urlTable,
+              routePath,
               data[this.relationPrimaryField.get(field)],
               camelToKebab(field)
             ),
@@ -240,12 +241,12 @@ export class TransformMixinService<T> {
       relationships[itemRelation as string] = {
         links: {
           self: this.getLink(
-            urlTable,
+            routePath,
             data[idNameField],
             'relationships',
             field
           ),
-          related: this.getLink(urlTable, data[idNameField], field),
+          related: this.getLink(routePath, data[idNameField], field),
         },
       };
     }
@@ -255,7 +256,7 @@ export class TransformMixinService<T> {
       attributes,
       relationships,
       links: {
-        self: this.getLink(urlTable, data[idNameField]),
+        self: this.getLink(routePath, data[idNameField]),
       },
     };
   }

--- a/libs/json-api-nestjs/src/lib/mixin/service/typeorm/methods/get-one/get-one.spec.ts
+++ b/libs/json-api-nestjs/src/lib/mixin/service/typeorm/methods/get-one/get-one.spec.ts
@@ -155,13 +155,15 @@ describe('GetOne methode test', () => {
   });
 
   it('should be correct if route is overriden', async () => {
-    expect.assertions(2);
+    expect.assertions(3);
     configParam.overrideRoute = 'overridden';
 
     const response = await typeormService.getOne({
       query: defaultField,
       route: { id: params },
     });
+
+    expect(response.data['type']).toContain('users');
 
     expect(response.data['relationships'].addresses.links.related).toContain(
       'overridden'


### PR DESCRIPTION
This fixes a mistake that I did when implementing path override routes.

We were mistakenly overriding resource `type` attribute when we should have just modified `relationships` paths.