### PR TITLE
fix(json-api-nestjs): fix enum and class validator

### DIFF
--- a/libs/json-api-nestjs/src/lib/factory/ajv/ajv.factory.spec.ts
+++ b/libs/json-api-nestjs/src/lib/factory/ajv/ajv.factory.spec.ts
@@ -8,7 +8,7 @@ import AjvCall from 'ajv';
 import { AjvCallFactory } from './ajv.factory';
 import { GLOBAL_MODULE_OPTIONS_TOKEN } from '../../constants';
 import { ModuleOptions, QueryParams } from '../../types';
-import { mockDBTestModule, entities, Users } from '../../mock-utils';
+import { mockDBTestModule, entities, Users, Comments } from '../../mock-utils';
 
 describe('AJV factory', () => {
   let options: ModuleOptions;
@@ -264,4 +264,20 @@ describe('AJV factory', () => {
       propsColumns
     );
   });
+
+  it('Should be correct dchema for enum field', () => {
+    const transformQuerySchema = ajvCall.getSchema<QueryParams<Comments>>(
+      `inputBodyPostSchema-${Comments.name}`
+    );
+    const {enum: enumData} = dataSource.getRepository(Comments).metadata.columns.find(i => i.propertyName === 'kind');
+    const dataProperty =
+      transformQuerySchema.schema['properties']['data']['properties']['attributes']['properties'];
+    expect(dataProperty).toHaveProperty('kind');
+    expect(dataProperty['kind']).toHaveProperty('type');
+    expect(dataProperty['kind']).toHaveProperty('enum');
+    expect(Array.isArray(dataProperty['kind']['enum'])).toEqual(true);
+    expect(dataProperty['kind']['enum']).toEqual(enumData);
+
+
+  })
 });

--- a/libs/json-api-nestjs/src/lib/factory/ajv/ajv.factory.ts
+++ b/libs/json-api-nestjs/src/lib/factory/ajv/ajv.factory.ts
@@ -25,7 +25,7 @@ export function AjvCallFactory(
   const AjvCallInst = new AjvCall({ allErrors: true });
 
   for (const entity of options.entities) {
-    const arrayProps: { [key: string]: boolean } = {};
+    const arrayProps: { [key: string]: boolean | any} = {};
     const uuidProps: { [key: string]: boolean } = {};
     const relationArrayProps: { [key: string]: { [key: string]: boolean } } =
       {};
@@ -38,6 +38,21 @@ export function AjvCallFactory(
       .filter((i) => !relations.includes(i.propertyName))
       .map((i) => {
         arrayProps[i.propertyName] = i.isArray;
+        if (i.isArray) {
+          arrayProps[i.propertyName] = {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+          };
+        }
+        if (i.type === 'enum') {
+          arrayProps[i.propertyName] = {
+            type: 'string',
+            enum: i.enum
+          };
+        }
+
         uuidProps[i.propertyName] = i.generationStrategy === 'uuid';
         return i.propertyName;
       });

--- a/libs/json-api-nestjs/src/lib/factory/ajv/utils/input-body-post-schema.ts
+++ b/libs/json-api-nestjs/src/lib/factory/ajv/utils/input-body-post-schema.ts
@@ -88,14 +88,7 @@ export function inputBodyPostSchema(
             type: 'string',
           };
       }
-      acum[item] = arrayPropsConfig.arrayProps[item]
-        ? {
-            type: 'array',
-            items: {
-              type: 'string',
-            },
-          }
-        : dataType;
+      acum[item] = arrayPropsConfig.arrayProps[item] === false ? dataType : arrayPropsConfig.arrayProps[item];
       return acum;
     }, {});
 

--- a/libs/json-api-nestjs/src/lib/mixin/pipes/body-input-patch/body-input-patch.pipe.ts
+++ b/libs/json-api-nestjs/src/lib/mixin/pipes/body-input-patch/body-input-patch.pipe.ts
@@ -80,6 +80,7 @@ export class BodyInputPatchPipe<Entity> implements PipeTransform {
 
     const validationErrors = await classValidate(temporaryEntity, {
       skipUndefinedProperties: true,
+      forbidUnknownValues: false
     });
 
     if (validationErrors.length > 0) {

--- a/libs/json-api-nestjs/src/lib/mixin/pipes/body-input-post/body-input-post.pipe.ts
+++ b/libs/json-api-nestjs/src/lib/mixin/pipes/body-input-post/body-input-post.pipe.ts
@@ -79,6 +79,7 @@ export class BodyInputPostPipe<Entity> implements PipeTransform {
 
     const validationErrors = await classValidate(temporaryEntity, {
       skipUndefinedProperties: false,
+      forbidUnknownValues: false
     });
 
     if (validationErrors.length > 0) {


### PR DESCRIPTION
1. Fix correct ajv schema for enum type of type orm
2. Add forbidUnknownValues for class-validator(https://github.com/typestack/class-validator/issues/1873)