### PR TITLE
fix(son-api-nestjs): escape  conditional 

### DIFF
--- a/libs/json-api-nestjs/src/lib/mixin/service/typeorm/methods/get-all/get-all.ts
+++ b/libs/json-api-nestjs/src/lib/mixin/service/typeorm/methods/get-all/get-all.ts
@@ -165,7 +165,7 @@ export async function getAll<T>(
     .innerJoin(
       `(${builder.getQuery()})`,
       'subQuery',
-      `"subQuery"."${subQueryIdAlias}" = ${countAlias}.${primaryColumn}`
+      `${builder.escape('subQuery')}.${builder.escape(subQueryIdAlias)} = ${countAlias}.${primaryColumn}`
     )
     .setParameters(builder.getParameters())
     .getRawMany<T>();


### PR DESCRIPTION
MySQL queries using double quotes instead of backtick

Closes #67